### PR TITLE
Add Support for GearScore

### DIFF
--- a/ElvUI_WrathArmory/Core/Core.lua
+++ b/ElvUI_WrathArmory/Core/Core.lua
@@ -3,6 +3,7 @@ local module = E:GetModule('ElvUI_WrathArmory')
 local S = E:GetModule('Skins')
 local LSM = E.Libs.LSM
 local LCS = E.Libs.LCS
+local LibGearScore = LibStub:GetLibrary("LibGearScore.1000", true)
 
 local values = {
 	SIDE_SLOTS_ANCHORPOINTS = {
@@ -374,14 +375,19 @@ function module:UpdateAverageString(frame, which, iLevelDB)
 
 	local db = E.db.wratharmory[string.lower(which)].avgItemLevel
 	local isCharPage = which == 'Character'
-	local AvgItemLevel = module:CalculateAverageItemLevel(iLevelDB, isCharPage and 'player' or frame.unit)
+	local _, GearScore = LibGearScore:GetScore(isCharPage and 'player' or frame.unit)
+	local AvgItemLevel = GearScore.AvgItemLevel
+	local AvgILvlAndGearScore = 'iLvl: '..AvgItemLevel
+	if db.gearScore then
+		AvgILvlAndGearScore = AvgILvlAndGearScore..'  GS: '..GearScore.GearScore
+	end
 
 	if AvgItemLevel then
 		if isCharPage then
-			frame.ItemLevelText:SetText(AvgItemLevel)
+			frame.ItemLevelText:SetText(AvgILvlAndGearScore)
 			frame.ItemLevelText:SetTextColor(db.color.r, db.color.g, db.color.b)
 		else
-			frame.ItemLevelText:SetText(AvgItemLevel)
+			frame.ItemLevelText:SetText(AvgILvlAndGearScore)
 			frame.ItemLevelText:SetTextColor(db.color.r, db.color.g, db.color.b)
 			frame.ItemLevelText:ClearAllPoints()
 			frame.ItemLevelText:Point('CENTER', _G['WrathArmory_'..which..'AvgItemLevel'], 0, -2)

--- a/ElvUI_WrathArmory/Libs/LibGearScore-1.0/CHANGES.txt
+++ b/ElvUI_WrathArmory/Libs/LibGearScore-1.0/CHANGES.txt
@@ -1,0 +1,14 @@
+tag 70fa74dc72aa809d79deac1f5b3994ef4bd713d1 1.0.r8
+Author:	Road-block <dridzt.addons@hotmail.com>
+Date:	Sun Oct 15 17:22:24 2023 +0300
+
+wrath P4 updates
+
+commit 0e4798c3e201e0beea8002dda3f5b9735b4bd8e9
+Author: Road-block <dridzt.addons@hotmail.com>
+Date:   Sun Oct 15 17:19:30 2023 +0300
+
+    add blizzard itemlevel calculation where available (player only)
+    add speculative dedicated insanity report (not 100% trusted it's not purely itemlevel check)
+    update embedded libs and interface versions for wrath P4
+

--- a/ElvUI_WrathArmory/Libs/LibGearScore-1.0/LICENSE
+++ b/ElvUI_WrathArmory/Libs/LibGearScore-1.0/LICENSE
@@ -1,0 +1,25 @@
+BSD 2-Clause License
+
+Copyright (c) 2022, Road-block
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/ElvUI_WrathArmory/Libs/LibGearScore-1.0/LibGearScore-1.0.toc
+++ b/ElvUI_WrathArmory/Libs/LibGearScore-1.0/LibGearScore-1.0.toc
@@ -1,0 +1,14 @@
+## Interface: 30403
+## Version: 1.0.r8
+## Title: Lib: GearScore-1.0
+## Notes: Uses the original GearScore Formula by Mirrikat45 (based on: ItemLevel, ItemRarity and PlayerClass/ItemSlot)
+## Author: Road-block
+## X-Website: https://github.com/Road-block/LibGearScore-1.0
+## X-Category: Library
+## X-License: Limited BSD
+## X-Credits: Mirrikat45
+## X-Curse-Project-ID: 724320
+
+Libs\LibStub\LibStub.lua
+Libs\CallbackHandler-1.0\CallbackHandler-1.0.xml
+LibGearScore.lua

--- a/ElvUI_WrathArmory/Libs/LibGearScore-1.0/LibGearScore-1.0_Wrath.toc
+++ b/ElvUI_WrathArmory/Libs/LibGearScore-1.0/LibGearScore-1.0_Wrath.toc
@@ -1,0 +1,14 @@
+## Interface: 30403
+## Version: 1.0.r8
+## Title: Lib: GearScore-1.0
+## Notes: Uses the original GearScore Formula by Mirrikat45 (based on: ItemLevel, ItemRarity and PlayerClass/ItemSlot)
+## Author: Road-block
+## X-Website: https://github.com/Road-block/LibGearScore-1.0
+## X-Category: Library
+## X-License: Limited BSD
+## X-Credits: Mirrikat45
+## X-Curse-Project-ID: 724320
+
+Libs\LibStub\LibStub.lua
+Libs\CallbackHandler-1.0\CallbackHandler-1.0.xml
+LibGearScore.lua

--- a/ElvUI_WrathArmory/Libs/LibGearScore-1.0/LibGearScore.lua
+++ b/ElvUI_WrathArmory/Libs/LibGearScore-1.0/LibGearScore.lua
@@ -1,0 +1,823 @@
+-----------------------------------------------------------------------------------------------------------------------
+-- Usage
+-- 1.  Get a reference to the library
+--     local LibGearScore = LibStub:GetLibrary("LibGearScore.1000",true)
+-- 2.  Call the LibGearScore:GetScore(unit_or_guid) method passing a unitid or unitguid to get a player's
+--     gearscore data. Player has to have been inspected sometime during the play
+--     session. History of gearscores is not retained past the session by this library.
+--     If you need data retention it would have to be implemented downstream by your addon.
+--  2a.local guid, gearScore = LibGearScore:GetScore("player")
+--     'gearScore' table members:
+--     {
+--       TimeStamp = TimeStamp, -- YYYYMMDDhhmmss (eg. 20221025134532) for easy string sortable comparisons
+--       PlayerName = PlayerName,
+--       PlayerRealm = PlayerRealm, -- Normalized Realm Name
+--       GearScore = GearScore, -- Number
+--       AvgItemLevel = AvgItemLevel, -- Number
+--       LFGItemLevel = AvgItemLevelWithBags -- Number
+--       LFGItemLevelPVP = AvrItemLevelPvP -- Number
+--       FLOPScore = FLOPScore, -- Number (bonus or minus itemlevels for Flame Leviathan vehicles)
+--       HeraldFails = hashTable, -- {slotName = itemlevel}
+--       InsanityFails = hashTable, -- {slotName = itemLevel}
+--       RawTime = RawTime, -- nilable: unixtime (can feed to date(fmt,RawTime) to get back human readable datetime)
+--       Color = color, -- nilable: ColorMixin
+--       FLOPColor = color, -- ColorMixin
+--       HeraldColor = color, -- ColorMixin
+--       InsanityColor = color, -- ColorMixin
+--       Description = description -- nilable: String
+--     }
+--     PlayerName / PlayerRealm == _G.UKNOWNOBJECT or GearScore = 0 indicates failure to calculate
+-- 3.  LibGearScore:GetItemScore(item) method passing itemid, itemstring or itemlink to get the ItemScore
+--     of a single item.
+--  3a.local itemID, itemScore = LibGearScore:GetItemScore(item)
+--     'itemScore' table members:
+--     {
+--       ItemScore=ItemScore, -- Number
+--       ItemLevel=ItemLevel, -- Number
+--       Red=Red, -- 0-1
+--       Green=Green, -- 0-1
+--       Blue=Blue, -- 0-1
+--       Description=Description, -- String
+--     }
+--     Description == _G.UNKNOWNOBJECT indicates invalid item, Description == _G.PENDING_INVITE indicates uncached item
+-- 4.  Callbacks: "LibGearScore_Update", "LibGearScore_ItemScore", "LibGearScore_ItemPending"
+--  4a.LibGearScore.RegisterCallback(addon, "LibGearScore_Update")
+--     function addon:LibGearScore_Update(guid, gearScore) -- see (2a) for `gearScore` members
+--       -- do something with gearScore for player guid
+--     end
+--     LibGearScore.RegisterCallback(addon, "LibGearScore_ItemScore")
+--     function addon:LibGearScore_ItemScore(itemid, itemScore) -- see (3a) for `itemScore` members
+--       -- do something with itemScore for itemid
+--     end
+--     LibGearScore.RegisterCallback(addon, "LibGearScore_ItemPending")
+--     function addon:LibGearScore_ItemPending(itemid)
+--       -- can for example monitor for the LibGearScore_ItemScore callback to have final item data
+--     end
+--
+-- Notes
+--     LibGearScore-1.0 does NOT initiate Inspects, it only passively monitors inspect results.
+-----------------------------------------------------------------------------------------------------------------------
+
+local MAJOR, MINOR = "LibGearScore.1000", 8
+assert(LibStub, format("%s requires LibStub.", MAJOR))
+local lib, oldMinor = LibStub:NewLibrary(MAJOR, MINOR)
+
+if not lib then return end
+
+local GUIDIsPlayer = _G.C_PlayerInfo.GUIDIsPlayer
+local GetPlayerInfoByGUID = _G.GetPlayerInfoByGUID
+local GetNormalizedRealmName = _G.GetNormalizedRealmName
+local GetItemInfoInstant = _G.GetItemInfoInstant
+local CanInspect = _G.CanInspect
+local CheckInteractDistance = _G.CheckInteractDistance
+local UnitIsVisible = _G.UnitIsVisible
+local GetServerTime = _G.GetServerTime
+local UnitGUID = _G.UnitGUID
+local UnitLevel = _G.UnitLevel
+local UnitIsPlayer = _G.UnitIsPlayer
+local UnitIsUnit = _G.UnitIsUnit
+local GetAverageItemLevel = _G.GetAverageItemLevel
+local Item = _G.Item
+local After = _G.C_Timer.After
+local CreateColor = _G.CreateColor
+local floor = _G.math.floor
+local max = _G.math.max
+local min = _G.math.min
+local modf = _G.math.modf
+
+local ScanTip = _G["LibGearScoreScanTooltip.1000"] or CreateFrame("GameTooltip", "LibGearScoreScanTooltip.1000", nil, "GameTooltipTemplate")
+if not ScanTip:IsOwned(WorldFrame) then
+  ScanTip:SetOwner(WorldFrame, "ANCHOR_NONE")
+end
+ScanTip:Hide()
+lib.callbacks = lib.callbacks or LibStub:GetLibrary("CallbackHandler-1.0"):New(lib)
+
+local BRACKET_SIZE = 1000
+
+if WOW_PROJECT_ID == WOW_PROJECT_WRATH_CLASSIC then
+  BRACKET_SIZE = 1000
+elseif WOW_PROJECT_ID == WOW_PROJECT_BURNING_CRUSADE_CLASSIC then
+  BRACKET_SIZE = 400
+elseif WOW_PROJECT_ID == WOW_PROJECT_CLASSIC then
+  BRACKET_SIZE = 200
+end
+local MAX_PLAYER_LEVEL = MAX_PLAYER_LEVEL_TABLE[LE_EXPANSION_LEVEL_CURRENT]
+local MAX_SCORE = BRACKET_SIZE*6-1
+local BASELINE, ARMOR_MAX, WEAPON_MAX, CLOAK_MAX = 200, 239, 245, 258
+local FLOPBASE, FLOPMAX, SCALING_FACTOR = 3000, 4225, 6
+local myGUID = UnitGUID("player")
+
+local AllSlots = {
+  _G.INVSLOT_HEAD,
+  _G.INVSLOT_NECK,
+  _G.INVSLOT_SHOULDER,
+  _G.INVSLOT_CHEST,
+  _G.INVSLOT_WAIST,
+  _G.INVSLOT_LEGS,
+  _G.INVSLOT_FEET,
+  _G.INVSLOT_WRIST,
+  _G.INVSLOT_HAND,
+  _G.INVSLOT_FINGER1,
+  _G.INVSLOT_FINGER2,
+  _G.INVSLOT_TRINKET1,
+  _G.INVSLOT_TRINKET2,
+  _G.INVSLOT_BACK,
+  _G.INVSLOT_MAINHAND,
+  _G.INVSLOT_OFFHAND,
+  _G.INVSLOT_RANGED,
+}
+
+local SlotMap = {
+  [_G.INVSLOT_HEAD] = _G.HEADSLOT,
+  [_G.INVSLOT_NECK] = _G.NECKSLOT,
+  [_G.INVSLOT_SHOULDER] = _G.SHOULDERSLOT,
+  [_G.INVSLOT_CHEST] = _G.CHESTSLOT,
+  [_G.INVSLOT_WAIST] = _G.WAISTSLOT,
+  [_G.INVSLOT_LEGS] = _G.LEGSSLOT,
+  [_G.INVSLOT_FEET] = _G.FEETSLOT,
+  [_G.INVSLOT_WRIST] = _G.WRISTSLOT,
+  [_G.INVSLOT_HAND] = _G.HANDSSLOT,
+  [_G.INVSLOT_FINGER1] = _G.FINGER0SLOT.."1",
+  [_G.INVSLOT_FINGER2] = _G.FINGER1SLOT.."2",
+  [_G.INVSLOT_TRINKET1] = _G.TRINKET0SLOT.."1",
+  [_G.INVSLOT_TRINKET2] = _G.TRINKET1SLOT.."2",
+  [_G.INVSLOT_BACK] = _G.BACKSLOT,
+  [_G.INVSLOT_MAINHAND] = _G.MAINHANDSLOT,
+  [_G.INVSLOT_OFFHAND] = _G.SECONDARYHANDSLOT,
+  [_G.INVSLOT_RANGED] = _G.RANGEDSLOT,
+}
+
+local GS_ItemSlots = {
+  [_G.INVSLOT_HEAD] = true,
+  [_G.INVSLOT_NECK] = true,
+  [_G.INVSLOT_SHOULDER] = true,
+  [_G.INVSLOT_CHEST] = true,
+  [_G.INVSLOT_WAIST] = true,
+  [_G.INVSLOT_LEGS] = true,
+  [_G.INVSLOT_FEET] = true,
+  [_G.INVSLOT_WRIST] = true,
+  [_G.INVSLOT_HAND] = true,
+  [_G.INVSLOT_FINGER1] = true,
+  [_G.INVSLOT_FINGER2] = true,
+  [_G.INVSLOT_TRINKET1] = true,
+  [_G.INVSLOT_TRINKET2] = true,
+  [_G.INVSLOT_BACK] = true,
+  [_G.INVSLOT_MAINHAND] = true,
+  [_G.INVSLOT_OFFHAND] = false,
+  [_G.INVSLOT_RANGED] = true,
+}
+
+local Flop_ItemSlots = { -- 15
+  [_G.INVSLOT_HEAD] = true,
+  [_G.INVSLOT_NECK] = true,
+  [_G.INVSLOT_SHOULDER] = true,
+  [_G.INVSLOT_CHEST] = true,
+  [_G.INVSLOT_WAIST] = true,
+  [_G.INVSLOT_LEGS] = true,
+  [_G.INVSLOT_FEET] = true,
+  [_G.INVSLOT_WRIST] = true,
+  [_G.INVSLOT_HAND] = true,
+  [_G.INVSLOT_FINGER1] = true,
+  [_G.INVSLOT_FINGER2] = true,
+  [_G.INVSLOT_TRINKET1] = true,
+  [_G.INVSLOT_TRINKET2] = true,
+  [_G.INVSLOT_BACK] = true,
+  [_G.INVSLOT_MAINHAND] = true,
+}
+
+local Herald_ItemSlots = {
+  [_G.INVSLOT_HEAD] = ARMOR_MAX,
+  [_G.INVSLOT_NECK] = ARMOR_MAX,
+  [_G.INVSLOT_SHOULDER] = ARMOR_MAX,
+  [_G.INVSLOT_CHEST] = ARMOR_MAX,
+  [_G.INVSLOT_WAIST] = ARMOR_MAX,
+  [_G.INVSLOT_LEGS] = ARMOR_MAX,
+  [_G.INVSLOT_FEET] = ARMOR_MAX,
+  [_G.INVSLOT_WRIST] = ARMOR_MAX,
+  [_G.INVSLOT_HAND] = ARMOR_MAX,
+  [_G.INVSLOT_FINGER1] = ARMOR_MAX,
+  [_G.INVSLOT_FINGER2] = ARMOR_MAX,
+  [_G.INVSLOT_TRINKET1] = ARMOR_MAX,
+  [_G.INVSLOT_TRINKET2] = ARMOR_MAX,
+  [_G.INVSLOT_BACK] = ARMOR_MAX,
+  [_G.INVSLOT_MAINHAND] = WEAPON_MAX,
+  [_G.INVSLOT_OFFHAND] = WEAPON_MAX,
+  [_G.INVSLOT_RANGED] = WEAPON_MAX, -- check if INVTYPE_RELIC needs special handling
+}
+
+local DedInsaniy_ItemSlots = {
+  [_G.INVSLOT_HEAD] = WEAPON_MAX,
+  [_G.INVSLOT_NECK] = WEAPON_MAX,
+  [_G.INVSLOT_SHOULDER] = WEAPON_MAX,
+  [_G.INVSLOT_CHEST] = WEAPON_MAX,
+  [_G.INVSLOT_WAIST] = WEAPON_MAX,
+  [_G.INVSLOT_LEGS] = WEAPON_MAX,
+  [_G.INVSLOT_FEET] = WEAPON_MAX,
+  [_G.INVSLOT_WRIST] = WEAPON_MAX,
+  [_G.INVSLOT_HAND] = WEAPON_MAX,
+  [_G.INVSLOT_FINGER1] = WEAPON_MAX,
+  [_G.INVSLOT_FINGER2] = WEAPON_MAX,
+  [_G.INVSLOT_TRINKET1] = WEAPON_MAX,
+  [_G.INVSLOT_TRINKET2] = WEAPON_MAX,
+  [_G.INVSLOT_BACK] = CLOAK_MAX,
+  [_G.INVSLOT_MAINHAND] = WEAPON_MAX,
+  [_G.INVSLOT_OFFHAND] = WEAPON_MAX,
+  [_G.INVSLOT_RANGED] = WEAPON_MAX,
+}
+
+local GS_ItemTypes = {
+  ["INVTYPE_RELIC"] = { ["SlotMOD"] = 0.3164, ["ItemSlot"] = 18, ["Enchantable"] = false},
+  ["INVTYPE_TRINKET"] = { ["SlotMOD"] = 0.5625, ["ItemSlot"] = 33, ["Enchantable"] = false },
+  ["INVTYPE_2HWEAPON"] = { ["SlotMOD"] = 2.000, ["ItemSlot"] = 16, ["Enchantable"] = true },
+  ["INVTYPE_WEAPONMAINHAND"] = { ["SlotMOD"] = 1.0000, ["ItemSlot"] = 16, ["Enchantable"] = true },
+  ["INVTYPE_WEAPONOFFHAND"] = { ["SlotMOD"] = 1.0000, ["ItemSlot"] = 17, ["Enchantable"] = true },
+  ["INVTYPE_RANGED"] = { ["SlotMOD"] = 0.3164, ["ItemSlot"] = 18, ["Enchantable"] = true },
+  ["INVTYPE_THROWN"] = { ["SlotMOD"] = 0.3164, ["ItemSlot"] = 18, ["Enchantable"] = false },
+  ["INVTYPE_RANGEDRIGHT"] = { ["SlotMOD"] = 0.3164, ["ItemSlot"] = 18, ["Enchantable"] = false },
+  ["INVTYPE_SHIELD"] = { ["SlotMOD"] = 1.0000, ["ItemSlot"] = 17, ["Enchantable"] = true },
+  ["INVTYPE_WEAPON"] = { ["SlotMOD"] = 1.0000, ["ItemSlot"] = 36, ["Enchantable"] = true },
+  ["INVTYPE_HOLDABLE"] = { ["SlotMOD"] = 1.0000, ["ItemSlot"] = 17, ["Enchantable"] = false },
+  ["INVTYPE_HEAD"] = { ["SlotMOD"] = 1.0000, ["ItemSlot"] = 1, ["Enchantable"] = true },
+  ["INVTYPE_NECK"] = { ["SlotMOD"] = 0.5625, ["ItemSlot"] = 2, ["Enchantable"] = false },
+  ["INVTYPE_SHOULDER"] = { ["SlotMOD"] = 0.7500, ["ItemSlot"] = 3, ["Enchantable"] = true },
+  ["INVTYPE_CHEST"] = { ["SlotMOD"] = 1.0000, ["ItemSlot"] = 5, ["Enchantable"] = true },
+  ["INVTYPE_ROBE"] = { ["SlotMOD"] = 1.0000, ["ItemSlot"] = 5, ["Enchantable"] = true },
+  ["INVTYPE_WAIST"] = { ["SlotMOD"] = 0.7500, ["ItemSlot"] = 6, ["Enchantable"] = false },
+  ["INVTYPE_LEGS"] = { ["SlotMOD"] = 1.0000, ["ItemSlot"] = 7, ["Enchantable"] = true },
+  ["INVTYPE_FEET"] = { ["SlotMOD"] = 0.75, ["ItemSlot"] = 8, ["Enchantable"] = true },
+  ["INVTYPE_WRIST"] = { ["SlotMOD"] = 0.5625, ["ItemSlot"] = 9, ["Enchantable"] = true },
+  ["INVTYPE_HAND"] = { ["SlotMOD"] = 0.7500, ["ItemSlot"] = 10, ["Enchantable"] = true },
+  ["INVTYPE_FINGER"] = { ["SlotMOD"] = 0.5625, ["ItemSlot"] = 31, ["Enchantable"] = false },
+  ["INVTYPE_CLOAK"] = { ["SlotMOD"] = 0.5625, ["ItemSlot"] = 15, ["Enchantable"] = true },
+  ["INVTYPE_BODY"] = { ["SlotMOD"] = 0, ["ItemSlot"] = 4, ["Enchantable"] = false },
+}
+
+local GS_Rarity = {
+  [0] = {Red = 0.55, Green = 0.55, Blue = 0.55 },
+  [1] = {Red = 1.00, Green = 1.00, Blue = 1.00 },
+  [2] = {Red = 0.12, Green = 1.00, Blue = 0.00 },
+  [3] = {Red = 0.00, Green = 0.50, Blue = 1.00 },
+  [4] = {Red = 0.69, Green = 0.28, Blue = 0.97 },
+  [5] = {Red = 0.94, Green = 0.09, Blue = 0.00 },
+  [6] = {Red = 1.00, Green = 0.00, Blue = 0.00 },
+  [7] = {Red = 0.90, Green = 0.80, Blue = 0.50 },
+}
+
+local GS_Formula = {
+  ["A"] = {
+    [4] = { ["A"] = 91.4500, ["B"] = 0.6500 },
+    [3] = { ["A"] = 81.3750, ["B"] = 0.8125 },
+    [2] = { ["A"] = 73.0000, ["B"] = 1.0000 }
+  },
+  ["B"] = {
+    [4] = { ["A"] = 26.0000, ["B"] = 1.2000 },
+    [3] = { ["A"] = 0.7500, ["B"] = 1.8000 },
+    [2] = { ["A"] = 8.0000, ["B"] = 2.0000 },
+    [1] = { ["A"] = 0.0000, ["B"] = 2.2500 }
+  }
+}
+
+local GS_Quality = {
+  [BRACKET_SIZE*6] = {
+    ["Red"] = { ["A"] = 0.94, ["B"] = BRACKET_SIZE*5, ["C"] = 0.00006, ["D"] = 1 },
+    ["Blue"] = { ["A"] = 0.47, ["B"] = BRACKET_SIZE*5, ["C"] = 0.00047, ["D"] = -1 },
+    ["Green"] = { ["A"] = 0, ["B"] = 0, ["C"] = 0, ["D"] = 0 },
+    ["Description"] = _G.ITEM_QUALITY5_DESC
+  },
+  [BRACKET_SIZE*5] = {
+    ["Red"] = { ["A"] = 0.69, ["B"] = BRACKET_SIZE*4, ["C"] = 0.00025, ["D"] = 1 },
+    ["Blue"] = { ["A"] = 0.28, ["B"] = BRACKET_SIZE*4, ["C"] = 0.00019, ["D"] = 1 },
+    ["Green"] = { ["A"] = 0.97, ["B"] = BRACKET_SIZE*4, ["C"] = 0.00096, ["D"] = -1 },
+    ["Description"] = _G.ITEM_QUALITY4_DESC
+  },
+  [BRACKET_SIZE*4] = {
+    ["Red"] = { ["A"] = 0.0, ["B"] = BRACKET_SIZE*3, ["C"] = 0.00069, ["D"] = 1 },
+    ["Blue"] = { ["A"] = 0.5, ["B"] = BRACKET_SIZE*3, ["C"] = 0.00022, ["D"] = -1 },
+    ["Green"] = { ["A"] = 1, ["B"] = BRACKET_SIZE*3, ["C"] = 0.00003, ["D"] = -1 },
+    ["Description"] = _G.ITEM_QUALITY3_DESC
+  },
+  [BRACKET_SIZE*3] = {
+    ["Red"] = { ["A"] = 0.12, ["B"] = BRACKET_SIZE*2, ["C"] = 0.00012, ["D"] = -1 },
+    ["Blue"] = { ["A"] = 1, ["B"] = BRACKET_SIZE*2, ["C"] = 0.00050, ["D"] = -1 },
+    ["Green"] = { ["A"] = 0, ["B"] = BRACKET_SIZE*2, ["C"] = 0.001, ["D"] = 1 },
+    ["Description"] = _G.ITEM_QUALITY2_DESC
+  },
+  [BRACKET_SIZE*2] = {
+    ["Red"] = { ["A"] = 1, ["B"] = BRACKET_SIZE, ["C"] = 0.00088, ["D"] = -1 },
+    ["Blue"] = { ["A"] = 1, ["B"] = 000, ["C"] = 0.00000, ["D"] = 0 },
+    ["Green"] = { ["A"] = 1, ["B"] = BRACKET_SIZE, ["C"] = 0.001, ["D"] = -1 },
+    ["Description"] = _G.ITEM_QUALITY1_DESC
+  },
+  [BRACKET_SIZE] = {
+    ["Red"] = { ["A"] = 0.55, ["B"] = 0, ["C"] = 0.00045, ["D"] = 1 },
+    ["Blue"] = { ["A"] = 0.55, ["B"] = 0, ["C"] = 0.00045, ["D"] = 1 },
+    ["Green"] = { ["A"] = 0.55, ["B"] = 0, ["C"] = 0.00045, ["D"] = 1 },
+    ["Description"] = _G.ITEM_QUALITY0_DESC
+  },
+}
+local tCount = function(t)
+  local count = 0
+  for k,v in pairs(t) do
+    count = count + 1
+  end
+  return count
+end
+
+local colorPoor = ITEM_QUALITY_COLORS[LE_ITEM_QUALITY_POOR].color
+local gradientColors = {
+  ITEM_QUALITY_COLORS[LE_ITEM_QUALITY_UNCOMMON].color,
+  ITEM_QUALITY_COLORS[LE_ITEM_QUALITY_RARE].color,
+  ITEM_QUALITY_COLORS[LE_ITEM_QUALITY_EPIC].color,
+  ITEM_QUALITY_COLORS[LE_ITEM_QUALITY_LEGENDARY].color,
+}
+local colorPass, colorFail = CreateColor(0,1,0,1), CreateColor(1,0,0,1)
+local function ColorGradient(percent, colors)
+  if not tonumber(percent) then return end
+  if tonumber(percent) > 1 then percent = 1 end
+  if tonumber(percent) < 0 then percent = 0 end
+
+  if not colors then
+    colors = gradientColors
+  end
+  local numColors = #colors
+
+  if percent >= 1 then
+    return colors[numColors]
+  elseif percent <= 0 then
+    return colors[1]
+  end
+
+  local segment, relative_percent = modf(percent*(numColors-1))
+  local rMin,gMin,bMin = colors[segment+1]:GetRGB()
+  local rMax,gMax,bMax = colors[segment+2]:GetRGB()
+
+  if ( not rMax or not gMax or not bMax ) then
+    return colors[1]
+  else
+    local r = rMin + (rMax - rMin)*relative_percent
+    local g = gMin + (gMax - gMin)*relative_percent
+    local b = bMin + (bMax - bMin)*relative_percent
+
+    return CreateColor(r,g,b,1)
+  end
+end
+
+local function heirloomLevel(unitLevel)
+  if unitLevel < 60 then
+    return unitLevel
+  elseif unitLevel < 70 then
+    return 3*(unitLevel-60)+85
+  elseif unitLevel <= 80 then
+    return 4*(unitLevel-70)+147
+  else
+    return 1
+  end
+end
+
+local function ResolveGUID(unitorguid)
+  if (unitorguid) then
+    if (GUIDIsPlayer(unitorguid)) then
+      return unitorguid
+    elseif (UnitIsPlayer(unitorguid)) then
+      return UnitGUID(unitorguid)
+    end
+  end
+  return nil
+end
+
+local function GetScoreColor(ItemScore)
+  local ItemScore = tonumber(ItemScore)
+  if (not ItemScore) then
+    return 0, 0, 0, _G.ITEM_QUALITY0_DESC
+  end
+
+  if (ItemScore > MAX_SCORE) then
+    ItemScore = MAX_SCORE
+  end
+  local Red = 0.1
+  local Blue = 0.1
+  local Green = 0.1
+  for i = 0,6 do
+    if ((ItemScore > i * BRACKET_SIZE) and (ItemScore <= ((i + 1) * BRACKET_SIZE))) then
+      local Red = GS_Quality[( i + 1 ) * BRACKET_SIZE].Red["A"] + (((ItemScore - GS_Quality[( i + 1 ) * BRACKET_SIZE].Red["B"])*GS_Quality[( i + 1 ) * BRACKET_SIZE].Red["C"])*GS_Quality[( i + 1 ) * BRACKET_SIZE].Red["D"])
+      local Blue = GS_Quality[( i + 1 ) * BRACKET_SIZE].Green["A"] + (((ItemScore - GS_Quality[( i + 1 ) * BRACKET_SIZE].Green["B"])*GS_Quality[( i + 1 ) * BRACKET_SIZE].Green["C"])*GS_Quality[( i + 1 ) * BRACKET_SIZE].Green["D"])
+      local Green = GS_Quality[( i + 1 ) * BRACKET_SIZE].Blue["A"] + (((ItemScore - GS_Quality[( i + 1 ) * BRACKET_SIZE].Blue["B"])*GS_Quality[( i + 1 ) * BRACKET_SIZE].Blue["C"])*GS_Quality[( i + 1 ) * BRACKET_SIZE].Blue["D"])
+      return Red, Green, Blue, GS_Quality[( i + 1 ) * BRACKET_SIZE].Description
+    end
+  end
+  return 0.1, 0.1, 0.1, _G.ITEM_QUALITY0_DESC
+end
+
+local function ItemScoreCalc(ItemRarity, ItemLevel, ItemEquipLoc)
+  local Table
+  local QualityScale = 1
+  local GearScore = 0
+  local unitLevel = lib.inspecting and lib.inspecting.level or UnitLevel("player")
+  local Scale = 1.8618
+  if (ItemRarity == 5) then
+    QualityScale = 1.3
+    ItemRarity = 4
+  elseif (ItemRarity == 1) then
+    QualityScale = 0.005
+    ItemRarity = 2
+  elseif (ItemRarity == 0) then
+    QualityScale = 0.005
+    ItemRarity = 2
+  elseif (ItemRarity == 7) then
+    ItemRarity = 3
+    ItemLevel = heirloomLevel(unitLevel)
+  end
+  if (ItemLevel > 120) then
+    Table = GS_Formula["A"]
+  else
+    Table = GS_Formula["B"]
+  end
+  if ((ItemRarity >= 2) and (ItemRarity <= 4)) then
+    local Red, Green, Blue, Description = GetScoreColor((floor(((ItemLevel - Table[ItemRarity].A) / Table[ItemRarity].B) * 1 * Scale)) * 11.25)
+    GearScore = floor(((ItemLevel - Table[ItemRarity].A) / Table[ItemRarity].B) * GS_ItemTypes[ItemEquipLoc].SlotMOD * Scale * QualityScale)
+    if (GearScore < 0) then
+      GearScore = 0
+      Red, Green, Blue, Description = GetScoreColor(1)
+    end
+    return GearScore, ItemLevel, Red, Green, Blue, Description
+  end
+end
+
+lib.ItemStale = {}
+lib.ItemScoreData = setmetatable({},{__index = function(cache, item)
+  local itemID, _, _, ItemEquipLoc = GetItemInfoInstant(item)
+  if not itemID then return {ItemScore=0, ItemLevel=0, ItemQuality = LE_ITEM_QUALITY_POOR, Red=0.1, Green=0.1, Blue=0.1, Description=_G.UNKNOWNOBJECT} end
+  if not GS_ItemTypes[ItemEquipLoc] then return {ItemScore=0, ItemLevel=0, ItemQuality = LE_ITEM_QUALITY_POOR, Red=0.1, Green=0.1, Blue=0.1, Description=_G.UNKNOWNOBJECT} end
+  local itemAsync = Item:CreateFromItemID(itemID)
+  if itemAsync:IsItemDataCached() then
+    local ItemLink = itemAsync:GetItemLink()
+    local ItemRarity = itemAsync:GetItemQuality()
+    local ItemLevelCurrent = itemAsync:GetCurrentItemLevel()
+    local ItemScore, ItemLevel, Red, Green, Blue, Description = ItemScoreCalc(ItemRarity, ItemLevelCurrent, ItemEquipLoc)
+    local scoreData = {ItemScore=ItemScore,ItemLevel=ItemLevel,ItemQuality=ItemRarity,Red=Red,Green=Green,Blue=Blue,Description=Description}
+    if ItemRarity == LE_ITEM_QUALITY_HEIRLOOM then
+      lib.ItemStale[itemID] = {item,ItemLink}
+    end
+    rawset(cache, item, scoreData)
+    rawset(cache, ItemLink, scoreData)
+    rawset(cache, itemID, scoreData)
+    lib.callbacks:Fire("LibGearScore_ItemScore", itemID, scoreData)
+    return cache[item]
+  else
+    itemAsync:ContinueOnItemLoad(function()
+      local ItemLink = itemAsync:GetItemLink()
+      local ItemRarity = itemAsync:GetItemQuality()
+      local ItemLevelCurrent = itemAsync:GetCurrentItemLevel()
+      local ItemScore, ItemLevel, Red, Green, Blue, Description = ItemScoreCalc(ItemRarity, ItemLevelCurrent, ItemEquipLoc)
+      local scoreData = {ItemScore=ItemScore,ItemLevel=ItemLevel,ItemQuality=ItemRarity,Red=Red,Green=Green,Blue=Blue,Description=Description}
+      if ItemRarity == LE_ITEM_QUALITY_HEIRLOOM then
+        lib.ItemStale[itemID] = {item,ItemLink}
+      end
+      rawset(cache, item, scoreData)
+      rawset(cache, ItemLink, scoreData)
+      rawset(cache, itemID, scoreData)
+      lib.callbacks:Fire("LibGearScore_ItemPending", itemID)
+    end)
+    return {ItemScore=0, ItemLevel=0, ItemQuality = LE_ITEM_QUALITY_POOR, Red=0.1, Green=0.1, Blue=0.1, Description=_G.PENDING_INVITE}
+  end
+end})
+
+local function GetUnitSlotLink(unit, slot)
+  if not ScanTip:IsOwned(WorldFrame) then
+    ScanTip:SetOwner(WorldFrame, "ANCHOR_NONE")
+  end
+  ScanTip:ClearLines()
+  ScanTip:SetInventoryItem(unit, slot)
+  ScanTip:Hide()
+  return GetInventoryItemLink(unit, slot) or select(2, ScanTip:GetItem())
+end
+
+local function CacheScore(guid, unit, level)
+  local _, enClass, _, _, _, PlayerName, PlayerRealm = GetPlayerInfoByGUID(guid)
+  if not PlayerName or PlayerName == _G.UNKNOWNOBJECT then return end
+  if PlayerRealm == "" then PlayerRealm = GetNormalizedRealmName() end
+  local GearScore = 0
+  local FLOPScore
+  local HeraldFails, DedInsanityFails = {}, {}
+  local ItemCount = 0
+  local LevelTotal = 0
+  local TitanGrip = 1
+  local ItemScore = 0
+  local ItemLevel = 0
+  local ItemQuality = 0
+  local AvgItemLevel = 0
+  local AvgItemLevelWithBags, AvgItemLevelEquip, AvgItemLevelPvP
+  local Description
+  if GetAverageItemLevel then
+    if (guid and guid == myGUID) or (unit and UnitIsUnit("player",unit)) then
+      AvgItemLevelWithBags, AvgItemLevelEquip, AvgItemLevelPvP = GetAverageItemLevel()
+    end
+  end
+  local mainHandLink = GetUnitSlotLink(unit, _G.INVSLOT_MAINHAND)
+  local offHandLink = GetUnitSlotLink(unit, _G.INVSLOT_OFFHAND)
+  if mainHandLink and offHandLink then
+    local itemID, _, _, ItemEquipLoc = GetItemInfoInstant(mainHandLink)
+    if ItemEquipLoc == "INVTYPE_2HWEAPON" then
+      TitanGrip = 0.5
+    end
+  end
+  if offHandLink then
+    local itemID, _, _, ItemEquipLoc = GetItemInfoInstant(offHandLink)
+    if ItemEquipLoc == "INVTYPE_2HWEAPON" then
+      TitanGrip = 0.5
+    end
+    local _, scoreData = lib:GetItemScore(offHandLink)
+    ItemScore, ItemLevel, Description = scoreData.ItemScore, scoreData.ItemLevel, scoreData.Description
+    if Description == _G.UNKNOWNOBJECT then return end
+    if Description == _G.PENDING_INVITE then
+      After(0.1, function()
+        CacheScore(guid, unit, level)
+        return
+      end)
+    end
+    if enClass == "HUNTER" then
+      ItemScore = ItemScore * 0.3164
+    end
+    GearScore = GearScore + ItemScore * TitanGrip
+    ItemCount = ItemCount + 1
+    LevelTotal = LevelTotal + ItemLevel
+  end
+  for _, slot in ipairs(AllSlots) do
+    local slotLink = GetUnitSlotLink(unit, slot)
+    if slotLink then
+      local _, scoreData = lib:GetItemScore(slotLink)
+      ItemScore, ItemLevel, ItemQuality, Description = scoreData.ItemScore, scoreData.ItemLevel, scoreData.ItemQuality, scoreData.Description
+      if Description == _G.UNKNOWNOBJECT then return end
+      if Description == _G.PENDING_INVITE then
+        After(0.1, function()
+          CacheScore(guid, unit, level)
+          return
+        end)
+      end
+      if GS_ItemSlots[slot] then
+        if enClass == "HUNTER" then
+          if slot == _G.INVSLOT_MAINHAND then
+            ItemScore = ItemScore * 0.3164
+          elseif slot == _G.INVSLOT_RANGED then
+            ItemScore = ItemScore * 5.3224
+          end
+        end
+        if slot == _G.INVSLOT_MAINHAND then
+          ItemScore = ItemScore * TitanGrip
+        end
+        GearScore = GearScore + ItemScore
+        ItemCount = ItemCount + 1
+        LevelTotal = LevelTotal + ItemLevel
+      end
+      if Flop_ItemSlots[slot] then
+        if ItemQuality == LE_ITEM_QUALITY_HEIRLOOM then ItemQuality = LE_ITEM_QUALITY_RARE end
+        if ItemQuality >= LE_ITEM_QUALITY_EPIC then
+          FLOPScore = (FLOPScore or 0) + (ItemLevel - BASELINE)
+        else
+          local qualityTax = (LE_ITEM_QUALITY_EPIC - ItemQuality) * 13
+          FLOPScore = (FLOPScore or 0) + (ItemLevel - BASELINE) - qualityTax
+        end
+      end
+      if Herald_ItemSlots[slot] then
+        local slotName = SlotMap[slot]
+        if ItemLevel > Herald_ItemSlots[slot] then
+          HeraldFails[slotName] = ItemLevel
+        else
+          if HeraldFails[slotName] then
+            HeraldFails[slotName] = nil
+          end
+        end
+      end
+      if DedInsaniy_ItemSlots[slot] then
+        local slotName = SlotMap[slot]
+        if ItemLevel > DedInsaniy_ItemSlots[slot] then
+          DedInsanityFails[slotName] = ItemLevel
+        else
+          if DedInsanityFails[slotName] then
+            DedInsanityFails[slotName] = nil
+          end
+        end
+      end
+    else
+      if Flop_ItemSlots[slot] then
+        FLOPScore = (FLOPScore or 0) - BASELINE
+      end
+    end
+  end
+  if GearScore > 0 and ItemCount > 0 then
+    GearScore = floor(GearScore)
+    if AvgItemLevelWithBags then
+      AvgItemLevel = floor(AvgItemLevelEquip) -- LFG tools use WithBags for PvE and PvP for PvP activities
+    else
+      AvgItemLevel = floor(LevelTotal/ItemCount)
+    end
+    local RawTime = GetServerTime()
+    local TimeStamp = date("%Y%m%d%H%M%S",RawTime) -- 20221017133545 (YYYYMMDDHHMMSS)
+    local r,g,b, description = GetScoreColor(GearScore)
+    local color = CreateColor(r,g,b,1)
+    local flopColor
+    if FLOPScore then
+      if FLOPScore < 0 then
+        flopColor = colorPoor
+      else
+        flopColor = ColorGradient(FLOPScore/(FLOPMAX-FLOPBASE))
+      end
+    end
+    local heraldColor, dedInsanityColor
+    if tCount(HeraldFails) > 0 then
+      heraldColor = colorFail
+    else
+      heraldColor = colorPass
+    end
+    if tCount(DedInsanityFails) > 0 then
+      dedInsanityColor = colorFail
+    else
+      dedInsanityColor = colorPass
+    end
+    local scoreData = {TimeStamp = TimeStamp, PlayerName = PlayerName, PlayerRealm = PlayerRealm, GearScore = GearScore, AvgItemLevel = AvgItemLevel, LFGItemLevel = AvgItemLevelWithBags, LFGItemLevelPVP = AvgItemLevelPvP, FLOPScore = FLOPScore, HeraldFails = HeraldFails, InsanityFails = DedInsanityFails, RawTime = RawTime, Color = color, FLOPColor = flopColor, HeraldColor = heraldColor, InsanityColor = dedInsanityColor, Description = description}
+    lib.PlayerScoreData[guid] = scoreData
+    lib.callbacks:Fire("LibGearScore_Update", guid, scoreData)
+  end
+end
+
+lib.PlayerScoreData = setmetatable({},{__index = function(cache, guid)
+  return {PlayerName = _G.UNKNOWNOBJECT, PlayerRealm = _G.UNKNOWNOBJECT, GearScore = 0, AvgItemLevel = 0}
+end})
+
+--------------
+--- Events ---
+--------------
+lib.eventFrame = lib.eventFrame or CreateFrame("Frame")
+lib.eventFrame:UnregisterAllEvents()
+lib.eventFrame:SetScript("OnEvent",nil)
+lib.eventFrame:RegisterEvent("PLAYER_ENTERING_WORLD")
+lib.eventFrame:RegisterEvent("PLAYER_EQUIPMENT_CHANGED")
+lib.eventFrame:RegisterEvent("UNIT_INVENTORY_CHANGED")
+lib.eventFrame:RegisterEvent("INSPECT_READY")
+lib.OnEvent = function(_,event,...)
+  return lib[event] and lib[event](lib,event,...)
+end
+lib.eventFrame:SetScript("OnEvent",lib.OnEvent)
+function lib:PLAYER_EQUIPMENT_CHANGED(event,...)
+  local guid, unit, level = UnitGUID("player"), "player", UnitLevel("player")
+  CacheScore(guid,unit,level)
+end
+function lib:UNIT_INVENTORY_CHANGED(event,...)
+  local unit = ...
+  if unit and UnitIsPlayer(unit) then
+    local guid, level = UnitGUID(unit), UnitLevel(unit)
+    if lib.inspecting and lib.inspecting.guid == guid then
+      CacheScore(guid, unit, level)
+    end
+  end
+end
+function lib:INSPECT_READY(event,...)
+  local guid = ...
+  if self.inspecting and self.inspecting.guid == guid then
+    if self.inspecting.unit and UnitIsVisible(self.inspecting.unit) then
+      if CanInspect(self.inspecting.unit,false) and CheckInteractDistance(self.inspecting.unit,1) then
+        CacheScore(self.inspecting.guid, self.inspecting.unit, self.inspecting.level)
+      end
+    end
+  end
+end
+function lib:PLAYER_ENTERING_WORLD(event,...)
+  local guid, level = UnitGUID("player"), UnitLevel("player")
+  CacheScore(guid, "player", level)
+end
+function lib.NotifyInspect(unit)
+  if unit and UnitIsPlayer(unit) then
+    local guid, level = UnitGUID(unit), UnitLevel(unit)
+    lib.inspecting = {guid=guid,unit=unit,level=level}
+  end
+end
+function lib.ClearInspectPlayer()
+  lib.inspecting = false
+end
+hooksecurefunc("NotifyInspect",lib.NotifyInspect)
+hooksecurefunc("ClearInspectPlayer",lib.ClearInspectPlayer)
+
+------------------
+--- Public API ---
+------------------
+function lib:GetItemScore(item)
+  local itemID = GetItemInfoInstant(item)
+  if itemID then
+    if lib.ItemStale[itemID] then -- invalidate heirlooms
+      local entry1, entry2 = lib.ItemStale[itemID][1], lib.ItemStale[itemID][2]
+      if rawget(lib.ItemScoreData,itemID) then
+        rawset(lib.ItemScoreData,itemID,nil)
+      end
+      if entry1 and rawget(lib.ItemScoreData,entry1) then
+        rawset(lib.ItemScoreData,entry1,nil)
+      end
+      if entry2 and rawget(lib.ItemScoreData,entry2) then
+        rawset(lib.ItemScoreData,entry2,nil)
+      end
+      lib.ItemStale[itemID] = nil
+    end
+    return itemID, lib.ItemScoreData[item]
+  end
+end
+
+function lib:GetScore(unitorguid)
+  local guid = ResolveGUID(unitorguid)
+  if (guid) then
+    return guid, lib.PlayerScoreData[guid]
+  end
+end
+
+function lib:GetScoreColor(score)
+  local r,g,b, desc = GetScoreColor(score)
+  local colorObj = CreateColor(r,g,b)
+  return colorObj, desc
+end
+
+function lib:GetSlotName(slot)
+  return SlotMap[slot] or slot
+end
+
+-- itemlevels_extra are the bonus (positive or negative) computed in GetScore for FLOPScore
+-- base can be baseHP (eg 1.134.000 for siege, 630.000 for demo, 504.000 for bike)
+-- or it can be baseDMG (eg 62636 for direct mortar hit)
+function lib:VehicleMath(itemlevels_extra, base)
+  if not itemlevels_extra then return end
+  -- SCALING_FACTOR/FLOPBASE*100 = 0.2
+  local percent_delta = itemlevels_extra * 0.2
+  if base then
+    return percent_delta, base*percent_delta/100
+  else
+    return percent_delta
+  end
+end
+
+-- return overall pass/fail and the array of fail slots
+function lib:HeraldCheck(unitorguid)
+  local guid = ResolveGUID(unitorguid)
+  if (guid) then
+    local scoreData = lib.PlayerScoreData[guid]
+    if scoreData and scoreData.HeraldFails then
+      local fail = tCount(scoreData.HeraldFails)>0
+      local pass = not fail
+      return pass, scoreData.HeraldFails, scoreData.HeraldColor
+    end
+  end
+end
+
+function lib:InsanityCheck(unitorguid)
+  local guid = ResolveGUID(unitorguid)
+  if (guid) then
+    local scoreData = lib.PlayerScoreData[guid]
+    if scoreData and scoreData.InsanityFails then
+      local fail = tCount(scoreData.InsanityFails)>0
+      local pass = not fail
+      return pass, scoreData.InsanityFails, scoreData.InsanityColor
+    end
+  end
+end
+
+---------------
+--- Testing ---
+---------------
+local function TargetScore()
+  if UnitExists("target")
+    and UnitIsPlayer("target")
+    and UnitIsFriend("target","player") then
+    local guid, scoreData = lib:GetScore("target")
+    if scoreData then
+      if scoreData.PlayerName == _G.UNKNOWNOBJECT then
+        print(format("No Gearcheck available for '%s'. Try inspecting first.",(UnitName("target"))))
+      else
+        print("GearScore: "..scoreData.Color:WrapTextInColorCode(scoreData.GearScore))
+        if scoreData.FLOPScore then
+          print("Vehicles: "..scoreData.FLOPColor:WrapTextInColorCode(scoreData.FLOPScore))
+          local percent_delta = lib:VehicleMath(scoreData.FLOPScore)
+          print(format("  %s%%",scoreData.FLOPColor:WrapTextInColorCode(percent_delta)))
+        end
+        if tCount(scoreData.HeraldFails) > 0 then
+          print("Herald: "..scoreData.HeraldColor:WrapTextInColorCode(_G.NO))
+          for k,v in pairs(scoreData.HeraldFails) do
+            print(format("  %s: %s",k,scoreData.HeraldColor:WrapTextInColorCode(v)))
+          end
+        else
+          print("Herald: "..scoreData.HeraldColor:WrapTextInColorCode(_G.YES))
+        end
+        if tCount(scoreData.InsanityFails) > 0 then
+          print("Ded.Insanity: "..scoreData.InsanityColor:WrapTextInColorCode(_G.NO))
+          for k,v in pairs(scoreData.InsanityFails) do
+            print(format("  %s: %s",k,scoreData.InsanityColor:WrapTextInColorCode(v)))
+          end
+        else
+          print("Ded.Insanity: "..scoreData.InsanityColor:WrapTextInColorCode(_G.YES))
+        end
+      end
+    else
+      print(format("No Gearcheck data available for '%s'. Try inspecting first.",(UnitName("target"))))
+    end
+  else
+    print(format("Can't get Gearcheck information for that target:%s",(UnitName("target")) or _G.TARGET_TOKEN_NOT_FOUND))
+  end
+end
+SLASH_LibGearScore1 = "/lib_gs"
+SLASH_LibGearScore2 = "/lib_gearscore"
+_G.SlashCmdList["LibGearScore"] = TargetScore

--- a/ElvUI_WrathArmory/Libs/LibGearScore-1.0/Libs/CallbackHandler-1.0/CallbackHandler-1.0.lua
+++ b/ElvUI_WrathArmory/Libs/LibGearScore-1.0/Libs/CallbackHandler-1.0/CallbackHandler-1.0.lua
@@ -1,0 +1,202 @@
+--[[ $Id: CallbackHandler-1.0.lua 1298 2022-12-12 15:10:10Z nevcairiel $ ]]
+local MAJOR, MINOR = "CallbackHandler-1.0", 8
+local CallbackHandler = LibStub:NewLibrary(MAJOR, MINOR)
+
+if not CallbackHandler then return end -- No upgrade needed
+
+local meta = {__index = function(tbl, key) tbl[key] = {} return tbl[key] end}
+
+-- Lua APIs
+local securecallfunction, error = securecallfunction, error
+local setmetatable, rawget = setmetatable, rawget
+local next, select, pairs, type, tostring = next, select, pairs, type, tostring
+
+
+local function Dispatch(handlers, ...)
+	local index, method = next(handlers)
+	if not method then return end
+	repeat
+		securecallfunction(method, ...)
+		index, method = next(handlers, index)
+	until not method
+end
+
+--------------------------------------------------------------------------
+-- CallbackHandler:New
+--
+--   target            - target object to embed public APIs in
+--   RegisterName      - name of the callback registration API, default "RegisterCallback"
+--   UnregisterName    - name of the callback unregistration API, default "UnregisterCallback"
+--   UnregisterAllName - name of the API to unregister all callbacks, default "UnregisterAllCallbacks". false == don't publish this API.
+
+function CallbackHandler.New(_self, target, RegisterName, UnregisterName, UnregisterAllName)
+
+	RegisterName = RegisterName or "RegisterCallback"
+	UnregisterName = UnregisterName or "UnregisterCallback"
+	if UnregisterAllName==nil then	-- false is used to indicate "don't want this method"
+		UnregisterAllName = "UnregisterAllCallbacks"
+	end
+
+	-- we declare all objects and exported APIs inside this closure to quickly gain access
+	-- to e.g. function names, the "target" parameter, etc
+
+
+	-- Create the registry object
+	local events = setmetatable({}, meta)
+	local registry = { recurse=0, events=events }
+
+	-- registry:Fire() - fires the given event/message into the registry
+	function registry:Fire(eventname, ...)
+		if not rawget(events, eventname) or not next(events[eventname]) then return end
+		local oldrecurse = registry.recurse
+		registry.recurse = oldrecurse + 1
+
+		Dispatch(events[eventname], eventname, ...)
+
+		registry.recurse = oldrecurse
+
+		if registry.insertQueue and oldrecurse==0 then
+			-- Something in one of our callbacks wanted to register more callbacks; they got queued
+			for event,callbacks in pairs(registry.insertQueue) do
+				local first = not rawget(events, event) or not next(events[event])	-- test for empty before. not test for one member after. that one member may have been overwritten.
+				for object,func in pairs(callbacks) do
+					events[event][object] = func
+					-- fire OnUsed callback?
+					if first and registry.OnUsed then
+						registry.OnUsed(registry, target, event)
+						first = nil
+					end
+				end
+			end
+			registry.insertQueue = nil
+		end
+	end
+
+	-- Registration of a callback, handles:
+	--   self["method"], leads to self["method"](self, ...)
+	--   self with function ref, leads to functionref(...)
+	--   "addonId" (instead of self) with function ref, leads to functionref(...)
+	-- all with an optional arg, which, if present, gets passed as first argument (after self if present)
+	target[RegisterName] = function(self, eventname, method, ... --[[actually just a single arg]])
+		if type(eventname) ~= "string" then
+			error("Usage: "..RegisterName.."(eventname, method[, arg]): 'eventname' - string expected.", 2)
+		end
+
+		method = method or eventname
+
+		local first = not rawget(events, eventname) or not next(events[eventname])	-- test for empty before. not test for one member after. that one member may have been overwritten.
+
+		if type(method) ~= "string" and type(method) ~= "function" then
+			error("Usage: "..RegisterName.."(\"eventname\", \"methodname\"): 'methodname' - string or function expected.", 2)
+		end
+
+		local regfunc
+
+		if type(method) == "string" then
+			-- self["method"] calling style
+			if type(self) ~= "table" then
+				error("Usage: "..RegisterName.."(\"eventname\", \"methodname\"): self was not a table?", 2)
+			elseif self==target then
+				error("Usage: "..RegisterName.."(\"eventname\", \"methodname\"): do not use Library:"..RegisterName.."(), use your own 'self'", 2)
+			elseif type(self[method]) ~= "function" then
+				error("Usage: "..RegisterName.."(\"eventname\", \"methodname\"): 'methodname' - method '"..tostring(method).."' not found on self.", 2)
+			end
+
+			if select("#",...)>=1 then	-- this is not the same as testing for arg==nil!
+				local arg=select(1,...)
+				regfunc = function(...) self[method](self,arg,...) end
+			else
+				regfunc = function(...) self[method](self,...) end
+			end
+		else
+			-- function ref with self=object or self="addonId" or self=thread
+			if type(self)~="table" and type(self)~="string" and type(self)~="thread" then
+				error("Usage: "..RegisterName.."(self or \"addonId\", eventname, method): 'self or addonId': table or string or thread expected.", 2)
+			end
+
+			if select("#",...)>=1 then	-- this is not the same as testing for arg==nil!
+				local arg=select(1,...)
+				regfunc = function(...) method(arg,...) end
+			else
+				regfunc = method
+			end
+		end
+
+
+		if events[eventname][self] or registry.recurse<1 then
+		-- if registry.recurse<1 then
+			-- we're overwriting an existing entry, or not currently recursing. just set it.
+			events[eventname][self] = regfunc
+			-- fire OnUsed callback?
+			if registry.OnUsed and first then
+				registry.OnUsed(registry, target, eventname)
+			end
+		else
+			-- we're currently processing a callback in this registry, so delay the registration of this new entry!
+			-- yes, we're a bit wasteful on garbage, but this is a fringe case, so we're picking low implementation overhead over garbage efficiency
+			registry.insertQueue = registry.insertQueue or setmetatable({},meta)
+			registry.insertQueue[eventname][self] = regfunc
+		end
+	end
+
+	-- Unregister a callback
+	target[UnregisterName] = function(self, eventname)
+		if not self or self==target then
+			error("Usage: "..UnregisterName.."(eventname): bad 'self'", 2)
+		end
+		if type(eventname) ~= "string" then
+			error("Usage: "..UnregisterName.."(eventname): 'eventname' - string expected.", 2)
+		end
+		if rawget(events, eventname) and events[eventname][self] then
+			events[eventname][self] = nil
+			-- Fire OnUnused callback?
+			if registry.OnUnused and not next(events[eventname]) then
+				registry.OnUnused(registry, target, eventname)
+			end
+		end
+		if registry.insertQueue and rawget(registry.insertQueue, eventname) and registry.insertQueue[eventname][self] then
+			registry.insertQueue[eventname][self] = nil
+		end
+	end
+
+	-- OPTIONAL: Unregister all callbacks for given selfs/addonIds
+	if UnregisterAllName then
+		target[UnregisterAllName] = function(...)
+			if select("#",...)<1 then
+				error("Usage: "..UnregisterAllName.."([whatFor]): missing 'self' or \"addonId\" to unregister events for.", 2)
+			end
+			if select("#",...)==1 and ...==target then
+				error("Usage: "..UnregisterAllName.."([whatFor]): supply a meaningful 'self' or \"addonId\"", 2)
+			end
+
+
+			for i=1,select("#",...) do
+				local self = select(i,...)
+				if registry.insertQueue then
+					for eventname, callbacks in pairs(registry.insertQueue) do
+						if callbacks[self] then
+							callbacks[self] = nil
+						end
+					end
+				end
+				for eventname, callbacks in pairs(events) do
+					if callbacks[self] then
+						callbacks[self] = nil
+						-- Fire OnUnused callback?
+						if registry.OnUnused and not next(callbacks) then
+							registry.OnUnused(registry, target, eventname)
+						end
+					end
+				end
+			end
+		end
+	end
+
+	return registry
+end
+
+
+-- CallbackHandler purposefully does NOT do explicit embedding. Nor does it
+-- try to upgrade old implicit embeds since the system is selfcontained and
+-- relies on closures to work.
+

--- a/ElvUI_WrathArmory/Libs/LibGearScore-1.0/Libs/CallbackHandler-1.0/CallbackHandler-1.0.xml
+++ b/ElvUI_WrathArmory/Libs/LibGearScore-1.0/Libs/CallbackHandler-1.0/CallbackHandler-1.0.xml
@@ -1,0 +1,4 @@
+<Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.blizzard.com/wow/ui/
+..\FrameXML\UI.xsd">
+	<Script file="CallbackHandler-1.0.lua"/>
+</Ui>

--- a/ElvUI_WrathArmory/Libs/LibGearScore-1.0/Libs/LibStub/LibStub.lua
+++ b/ElvUI_WrathArmory/Libs/LibGearScore-1.0/Libs/LibStub/LibStub.lua
@@ -1,0 +1,30 @@
+-- LibStub is a simple versioning stub meant for use in Libraries.  http://www.wowace.com/wiki/LibStub for more info
+-- LibStub is hereby placed in the Public Domain Credits: Kaelten, Cladhaire, ckknight, Mikk, Ammo, Nevcairiel, joshborke
+local LIBSTUB_MAJOR, LIBSTUB_MINOR = "LibStub", 2  -- NEVER MAKE THIS AN SVN REVISION! IT NEEDS TO BE USABLE IN ALL REPOS!
+local LibStub = _G[LIBSTUB_MAJOR]
+
+if not LibStub or LibStub.minor < LIBSTUB_MINOR then
+	LibStub = LibStub or {libs = {}, minors = {} }
+	_G[LIBSTUB_MAJOR] = LibStub
+	LibStub.minor = LIBSTUB_MINOR
+
+	function LibStub:NewLibrary(major, minor)
+		assert(type(major) == "string", "Bad argument #2 to `NewLibrary' (string expected)")
+		minor = assert(tonumber(string.match(minor, "%d+")), "Minor version must either be a number or contain a number.")
+
+		local oldminor = self.minors[major]
+		if oldminor and oldminor >= minor then return nil end
+		self.minors[major], self.libs[major] = minor, self.libs[major] or {}
+		return self.libs[major], oldminor
+	end
+
+	function LibStub:GetLibrary(major, silent)
+		if not self.libs[major] and not silent then
+			error(("Cannot find a library instance of %q."):format(tostring(major)), 2)
+		end
+		return self.libs[major], self.minors[major]
+	end
+
+	function LibStub:IterateLibraries() return pairs(self.libs) end
+	setmetatable(LibStub, { __call = LibStub.GetLibrary })
+end

--- a/ElvUI_WrathArmory/Libs/LibGearScore-1.0/README.md
+++ b/ElvUI_WrathArmory/Libs/LibGearScore-1.0/README.md
@@ -1,0 +1,96 @@
+# LibGearScore-1.0
+World of Warcraft Wrath (Classic) embeddable GearScore calculation library.  
+Formulas from original GearScore/Lite by Mirrikat45.
+
+## Usage/API
+0. If not using it standalone but embedded then in your addon .toc file or embeds.xml / libs.xml whatever is used to reference libraries.
+ ```
+ <path_to>\LibStub.lua
+ <path_to>\CallbackHandler-1.0.xml
+ <path_to>\LibGearScore.lua
+ ```
+
+1. Get a reference to the library
+ ```lua
+ local LibGearScore = LibStub:GetLibrary("LibGearScore.1000",true)
+ ```
+
+2. Call the public :GetScore() method passing a unitid or unitguid to get back GearScore data
+ ```lua
+ local guid, gearScore = LibGearScore:GetScore("player")
+ ```
+
+ Player has to have been inspected during the play session. 
+ History of scores is not retained beyond the current session by this library.
+ If data retention is required it has to be implemented downstream by the addon embedding or referencing the library.
+ 
+ `gearScore`members
+ ```lua
+ {
+  TimeStamp = YYYYMMDDhhmmss, -- string (eg. 20221025134532) for easy string sortable comparisons
+  PlayerName = PlayerName, -- string
+  PlayerRealm = PlayerRealm, -- string:Normalized Realm Name
+  GearScore = N, -- Number
+  AvgItemLevel = N, -- Number
+  RawTime = xxxxxxxxxx, -- number/nilable: unixtime (can feed to date(fmt,RawTime) to get back human readable datetime)
+  Color = colorobject, -- ColorMixin/nilable -- can call colorobject:WrapTextInColorCode(text) for example
+  Description = qualitydescription -- nilable: String
+ }
+ ```
+ ```lua
+ if gearScore.PlayerName == _G.UNKNOWNOBJECT or gearScore.GearScore == 0 then
+   -- we don't have data for this unit
+ end
+ ```
+3. call the public GetItemScore() method passing itemid, itemstring or itemlink to get the base Score for a single item
+ 
+ ```lua
+ local itemID, itemScore = LibGearScore:GetItemScore(item)
+ ```
+ `itemScore`members
+ ```lua
+ {
+  ItemScore=ItemScore, -- Number
+  ItemLevel=ItemLevel, -- Number
+  Red=r, -- 0-1
+  Green=g, -- 0-1
+  Blue=b, -- 0-1
+  Description=qualitydescription, -- String
+ }
+ ```
+ ```lua
+ if itemScore.Description == _G.UNKNOWNOBJECT then
+  -- invalid item
+ end
+ if itemScore.Description == _G.PENDING_INVITE then
+  -- item is not in local cache, see callbacks below
+ end
+ ```
+ 
+ 4.  Callbacks: 
+  "LibGearScore_Update", "LibGearScore_ItemScore", "LibGearScore_ItemPending" events are sent by the library to addons registering for them.
+  (requires LibStub) 
+  
+  In addon code: (_addon is your addon object_)
+  ```lua
+  LibGearScore.RegisterCallback(addon, "LibGearScore_Update")
+  function addon:LibGearScore_Update(guid, gearScore) -- see (2a) for `gearScore` members
+    -- do something with gearScore for player guid
+  end
+  --
+  LibGearScore.RegisterCallback(addon, "LibGearScore_ItemScore")
+  function addon:LibGearScore_ItemScore(itemid, itemScore) -- see (3a) for `itemScore` members
+    -- do something with itemScore for itemid
+  end
+  LibGearScore.RegisterCallback(addon, "LibGearScore_ItemPending")
+  function addon:LibGearScore_ItemPending(itemid)
+    -- can for example monitor for the LibGearScore_ItemScore callback to have final item data
+  end
+  ```
+5. Testing 
+  
+  `/lib_gs` with a player targetted in-game.
+
+## Notes
+  **LibGearScore-1.0** does not initiate Inspects.  
+  It passively caches and provides GearScore results from Inspections started by the player manually or by other addons (including the addon embedding it)

--- a/ElvUI_WrathArmory/Libs/Load_Libs.xml
+++ b/ElvUI_WrathArmory/Libs/Load_Libs.xml
@@ -1,3 +1,6 @@
 <Ui xmlns='http://www.blizzard.com/wow/ui/'>
 	<Include file='LibGetEnchant-1.0\LibGetEnchant-1.0.xml'/>
+	<Script file='LibGearScore-1.0\Libs\LibStub\LibStub.lua'/>
+	<Include file='LibGearScore-1.0\Libs\CallbackHandler-1.0\CallbackHandler-1.0.xml'/>
+	<Script file='LibGearScore-1.0\LibGearScore.lua'/>
 </Ui>

--- a/ElvUI_WrathArmory/Options/Options.lua
+++ b/ElvUI_WrathArmory/Options/Options.lua
@@ -26,7 +26,7 @@ local SideSlotGrowthDirection = {
 }
 
 local function actionGroup(info, which, groupName, ...)
-	local force = groupName == 'gems' or groupName == 'warningIndicator'
+	local force = groupName == 'gems' or groupName == 'warningIndicator' or groupName == 'avgItemLevel'
 	if info.type == 'color' then
 		local color = E.db.wratharmory[which][groupName][info[#info]]
 		local r, g, b, a = ...
@@ -82,6 +82,7 @@ local SharedOptions = {
 local function GetOptionsTable_AvgItemLevelGroup(which, groupName)
 	local config = ACH:Group(L["Average Item Level"], nil, 5, 'tab', function(info) return actionGroup(info, which, groupName) end, function(info, ...) actionGroup(info, which, groupName, ...) end)
 	config.args = CopyTable(SharedOptions)
+	config.args.gearScore = ACH:Toggle(L["Show GearScore"], nil, 0)
 	config.args.font = ACH:SharedMediaFont(L["Font"], nil, 2)
 	config.args.fontOutline = ACH:FontFlags(L["Font Outline"], nil, 3)
 	config.args.fontSize = ACH:Range(L["Font Size"], nil, 4, C.Values.FontSize)


### PR DESCRIPTION
Add support for showing GearScore in the Character and Inspect frames. This is shown in addition to average item level.

Showing GearScore is disabled by default to retain the current experience. Players can enable it in the Options if they want to see GearScore. They will have to enable it individually for the Character/Inspect frames -- this is done to retain the current options experience of keeping these settings different.